### PR TITLE
add length operator overload to ImVec2

### DIFF
--- a/lua/imgui_base.lua
+++ b/lua/imgui_base.lua
@@ -49,6 +49,7 @@ ImVec2 = {
         return ImVec2(a.x * b, a.y * b) end
         return ImVec2(a * b.x, a * b.y)
     end,
+	__len = function(a) return math.sqrt(a.x*a.x+a.y*a.y) end,
 	norm = function(a)
 		return math.sqrt(a.x*a.x+a.y*a.y)
 	end,


### PR DESCRIPTION
Might be useful to write `#vec` and get the length of the vector (instead of `norm` where I'd expect the normal vector :) ) 